### PR TITLE
Add hidden/unused parameters as document objects/properties

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -205,6 +205,28 @@ namespace NLog.Targets.ElasticSearch
                     }
                 }
 
+                if (logEvent.Parameters.Any())
+                {
+                    foreach (var p in logEvent.Parameters.Where(p => logEvent.Properties.Values.Contains(p) == false))
+                    {
+                        if (p is KeyValuePair<string, object>)
+                        {
+                            KeyValuePair<string, object> kvp = (KeyValuePair<string, object>)p;
+                            document[kvp.Key] = kvp.Value;
+                        }
+                        else if (p is string[])
+                        {
+                            var strPropertyArray = p as string[];
+                            document[strPropertyArray[0]] = strPropertyArray[1];
+                        }
+                        else if (p is Dictionary<string, object>)
+                        {
+                            var paramsDict = p as Dictionary<string, object>;
+                            document = document.Union(paramsDict).ToDictionary(pair => pair.Key, pair => pair.Value);
+                        }
+                    }
+                }
+
                 var index = Index.Render(logEvent).ToLowerInvariant();
                 var type = DocumentType.Render(logEvent);
 


### PR DESCRIPTION
Allowing unused parameters in the formatted message to be added as objects in the document submitted to Elasticsearch. For example:
Logger.Error("Error message {0}", p1, new [] {"object key", "object value"})
In the above example the third parameter is unused for formatting, but it is in a form that can be converted to a document entry for ElasticSearch. With this change it will be added as an object to the root document submitted to the ElasticSearch target. The accepted object types are: string[], KeyValuePair<string, object>, and Dictionary<string, object>. In the case of string[] the first two items are used to make the object.
This feature is very valuable in my use cases. The processing and inclusion of additional data is light weight and simple while keeping the message sent to other NLog targets clean.