### PR TITLE
Added support for Pipeline, only published when configured

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -61,6 +61,16 @@ namespace NLog.Targets.ElasticSearch
         public bool DisableAutomaticProxyDetection { get; set; }
 
         /// <summary>
+        /// Set it to true to disable use of ping to checking if node is alive
+        /// </summary>
+        public bool DisablePing { get; set; }
+
+        /// <summary>
+        /// Set it to true to enable HttpCompression (Must be enabled on server)
+        /// </summary>
+        public bool EnableHttpCompression { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the elasticsearch index to write to.
         /// </summary>
         public Layout Index { get; set; } = "logstash-${date:format=yyyy.MM.dd}";
@@ -130,6 +140,12 @@ namespace NLog.Targets.ElasticSearch
             if (DisableAutomaticProxyDetection)
                 config.DisableAutomaticProxyDetection();
 
+            if (DisablePing)
+                config.DisablePing();
+
+            if (EnableHttpCompression)
+                config.EnableHttpCompression();
+
             _client = new ElasticLowLevelClient(config);
 
             if (!string.IsNullOrEmpty(ExcludedProperties))
@@ -146,7 +162,7 @@ namespace NLog.Targets.ElasticSearch
             SendBatch(logEvents);
         }
 
-        private void SendBatch(IList<AsyncLogEventInfo> logEvents)
+        private void SendBatch(ICollection<AsyncLogEventInfo> logEvents)
         {
             try
             {

--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -14,7 +14,7 @@ namespace NLog.Targets.ElasticSearch
     public class ElasticSearchTarget : TargetWithLayout, IElasticSearchTarget
     {
         private IElasticLowLevelClient _client;
-        private List<string> _excludedProperties = new List<string>(new[] { "CallerMemberName", "CallerFilePath", "CallerLineNumber", "MachineName", "ThreadId" });
+        private HashSet<string> _excludedProperties = new HashSet<string>(new[] { "CallerMemberName", "CallerFilePath", "CallerLineNumber", "MachineName", "ThreadId" });
         private readonly JsonSerializerSettings _jsonSerializerSettings = CreateJsonSerializerSettings();
 
         static JsonSerializerSettings CreateJsonSerializerSettings()
@@ -149,7 +149,7 @@ namespace NLog.Targets.ElasticSearch
             _client = new ElasticLowLevelClient(config);
 
             if (!string.IsNullOrEmpty(ExcludedProperties))
-                _excludedProperties = ExcludedProperties.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+                _excludedProperties = new HashSet<string>(ExcludedProperties.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
         }
 
         protected override void Write(AsyncLogEventInfo logEvent)

--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="6.0.2" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.1.0" />
     <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/NLog.Targets.ElasticSearch/StringExtensions.cs
+++ b/src/NLog.Targets.ElasticSearch/StringExtensions.cs
@@ -55,7 +55,7 @@ namespace NLog.Targets.ElasticSearch
 #else
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true, true);
+                .AddJsonFile("appsettings.json", true, reloadOnChange: false);  // CreateFileWatcher not supported on all platforms, and not needed
 
             var configuration = builder.Build();
 


### PR DESCRIPTION
Resolves #49 for platforms not supporting FileWatcher.

Resolves #68 by re-adding pipeline support (Reverted in #33). Now it only adds Pipeline when it is configured.

Improves error-logging by not rethrowing exceptions, as it will affect original stacktrace.

Updated to Elasticsearch.Net ver. 6.1.0 and added support for setting config parameters `DisablePing` and `EnableHttpCompression`