### PR TITLE
Exceptions with properties that throw an exception when fetched fail to log

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root=true
+
+[*.config]
+indent_style=space
+indent_size=2
+
+[*.cs]
+indent_style=space
+indent_size=4
+trim_trailing_whitespace=true

--- a/src/NLog.Targets.ElasticSearch.Tests/IntegrationTests.cs
+++ b/src/NLog.Targets.ElasticSearch.Tests/IntegrationTests.cs
@@ -1,12 +1,64 @@
 ﻿using System;
+using NLog.Common;
 using NLog.Config;
+using NLog.Layouts;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace NLog.Targets.ElasticSearch.Tests
 {
     public class IntegrationTests
     {
-        [Fact(Skip ="Integration")]
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public IntegrationTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        private class ExceptionWithPropertiesThatThrow : Exception
+        {
+            public object ThisPropertyThrowsOnGet => throw new ObjectDisposedException("DisposedObject");
+        }
+
+        [Theory(Skip = "Integration")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ExceptionSerializationTest(bool hasExceptionFieldLayout)
+        {
+            using (var testOutputTextWriter = new TestOutputTextWriter(testOutputHelper))
+            {
+                InternalLogger.LogWriter = testOutputTextWriter;
+                InternalLogger.LogLevel = LogLevel.Warn;
+
+                var elasticTarget = new ElasticSearchTarget();
+
+                if (hasExceptionFieldLayout)
+                {
+                    elasticTarget.Fields.Add(new Field
+                    {
+                        Name = "exception",
+                        Layout = Layout.FromString("${exception:format=toString,Data:maxInnerExceptionLevel=10}"),
+                        LayoutType = typeof(string)
+                    });
+                }
+
+                var rule = new LoggingRule("*", LogLevel.Info, elasticTarget);
+
+                var config = new LoggingConfiguration();
+                config.LoggingRules.Add(rule);
+
+                LogManager.Configuration = config;
+
+                var logger = LogManager.GetLogger("Example");
+
+                logger.Error(new ExceptionWithPropertiesThatThrow(), "Boom");
+
+                LogManager.Flush();
+            }
+        }
+
+        [Fact(Skip = "Integration")]
         public void SimpleLogTest()
         {
             var elasticTarget = new ElasticSearchTarget();

--- a/src/NLog.Targets.ElasticSearch.Tests/TestOutputTextWriter.cs
+++ b/src/NLog.Targets.ElasticSearch.Tests/TestOutputTextWriter.cs
@@ -1,0 +1,48 @@
+﻿using System.IO;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace NLog.Targets.ElasticSearch.Tests
+{
+    public class TestOutputTextWriter : TextWriter
+    {
+        private StringBuilder stringBuilder;
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public TestOutputTextWriter(ITestOutputHelper testOutputHelper)
+        {
+            this.stringBuilder = new StringBuilder();
+            this.testOutputHelper = testOutputHelper;
+        }
+
+        public override Encoding Encoding => Encoding.Unicode;
+
+        public override void Write(char value)
+        {
+            this.stringBuilder.Append(value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            this.stringBuilder.Append(value);
+
+            this.Flush();
+        }
+
+        public override void Flush()
+        {
+            var sb = this.stringBuilder;
+            if (sb.Length > 0)
+            {
+                this.stringBuilder = new StringBuilder();
+                this.testOutputHelper.WriteLine(sb.ToString());
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.Flush();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -282,6 +282,11 @@ namespace NLog.Targets.ElasticSearch
         {
             var jsonSerializerSettings = new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore, CheckAdditionalContent = true };
             jsonSerializerSettings.Converters.Add(new StringEnumConverter());
+            jsonSerializerSettings.Error = (sender, args) =>
+            {
+                InternalLogger.Warn(args.ErrorContext.Error, $"Error serializing exception property '{args.ErrorContext.Member}', property ignored");
+                args.ErrorContext.Handled = true;
+            };
             return jsonSerializerSettings;
         }
     }

--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -220,13 +220,6 @@ namespace NLog.Targets.ElasticSearch
                     {"message", RenderLogEvent(Layout, logEvent)}
                 };
 
-                if (logEvent.Exception != null)
-                {
-                    var jsonString = JsonConvert.SerializeObject(logEvent.Exception, _jsonSerializerSettings.Value);
-                    var ex = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
-                    document.Add("exception", ex.ReplaceDotInKeys());
-                }
-
                 foreach (var field in Fields)
                 {
                     var renderedField = RenderLogEvent(field.Layout, logEvent);
@@ -243,6 +236,13 @@ namespace NLog.Targets.ElasticSearch
                         _jsonSerializer = null; // Reset as it might now be in bad state
                         InternalLogger.Error(ex, "ElasticSearch: Error while formatting field: {0}", field.Name);
                     }
+                }
+
+                if (logEvent.Exception != null && !document.ContainsKey("exception"))
+                {
+                    var jsonString = JsonConvert.SerializeObject(logEvent.Exception, _jsonSerializerSettings.Value);
+                    var ex = JsonConvert.DeserializeObject<ExpandoObject>(jsonString);
+                    document.Add("exception", ex.ReplaceDotInKeys());
                 }
 
                 if (IncludeAllProperties && logEvent.HasProperties)


### PR DESCRIPTION
Hi,

We've come across an issue with the ElasticSearch target where, if we attempt to log an entry with an exception attached, and that exception has a property that can't be fetched due to throwing an exception, that causes the log message (or in fact an entire batch of log messages, if buffering is involved) to be lost.

This PR contains a change that means that properties causing errors while serializing are skipped instead of throwing an exception, and instead a warning is logged to the NLog internal log. It also avoids doing exception serialization at all if there is a custom field configured for exceptions.