### PR TITLE
Adds support for elastic cloud ids.

### DIFF
--- a/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
@@ -19,6 +19,11 @@ namespace NLog.Targets.ElasticSearch
         string Uri { get; set; }
 
         /// <summary>
+        /// Gets or sets the elasticsearch cloud id.
+        /// </summary>
+        string CloudId { get; set; }
+
+        /// <summary>
         /// Set it to true if ElasticSearch uses BasicAuth
         /// </summary>
         bool RequireAuth { get; set; }


### PR DESCRIPTION
Adds support for cloud id connection pool.
Things to note: username and password authentication is required when using cloud id connection pool but I haven't checked that they're provided - the connection _should_ just fail authentication.

I also don't check the `RequireAuth` property, as we know it is implicitly true in this scenario. If `RequireAuth` is also set to true then the username and password will be applied again (with the same values). Not sure whether this would cause any problems downstream, but I suspect not.