### PR TITLE
ElasticSearchTarget - Added MaxRecursionLimit to prevent Stack-overflow

### DIFF
--- a/src/NLog.Targets.ElasticSearch/FlatObjectContractResolver.cs
+++ b/src/NLog.Targets.ElasticSearch/FlatObjectContractResolver.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace NLog.Targets.ElasticSearch
+{
+    /// <summary>
+    /// Serializes all non-simple properties as object.ToString()
+    /// </summary>
+    internal sealed class FlatObjectContractResolver : DefaultContractResolver
+    {
+        private readonly FlatObjectConverter _flatObjectConverter = new FlatObjectConverter();
+
+        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        {
+            var jsonProperty = base.CreateProperty(member, memberSerialization);
+            if (jsonProperty.Readable && !IsSimpleType(jsonProperty.PropertyType))
+                jsonProperty.Converter = _flatObjectConverter;
+            return jsonProperty;
+        }
+
+        private static bool IsSimpleType(Type propertyType)
+        {
+            return propertyType != null && (Type.GetTypeCode(propertyType) != TypeCode.Object || propertyType.IsValueType);
+        }
+
+        private class FlatObjectConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return true;
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                return null;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                if (value == null)
+                {
+                    writer.WriteNull();
+                }
+                else if (value is System.Collections.IEnumerable)
+                {
+                    writer.WriteNull();
+                }
+                else
+                {
+                    writer.WriteValue(value.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/NLog.Targets.ElasticSearch/ObjectConverter.cs
+++ b/src/NLog.Targets.ElasticSearch/ObjectConverter.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NLog.Targets.ElasticSearch
+{
+    internal static class ObjectConverter
+    {
+        public static object FormatValueSafe(object value, int maxRecursionLimit, JsonSerializer jsonSerializer)
+        {
+            if (value is Exception)
+            {
+                return FormatToExpandoObject(value, jsonSerializer);
+            }
+            else if (maxRecursionLimit >= 0)
+            {
+                if (Convert.GetTypeCode(value) != TypeCode.Object || value.GetType().IsValueType)
+                {
+                    return value;
+                }
+                else if (maxRecursionLimit == 0)
+                {
+                    if (value is System.Collections.IEnumerable)
+                        return null;
+                    else
+                        return value.ToString();
+                }
+                else if (jsonSerializer.ContractResolver.ResolveContract(value.GetType()) is Newtonsoft.Json.Serialization.JsonObjectContract)
+                {
+                    return FormatToExpandoObject(value, jsonSerializer);
+                }
+            }
+
+            return value;
+        }
+
+        private static object FormatToExpandoObject(object value, JsonSerializer jsonSerializer)
+        {
+            string field = SerializeToJson(value, jsonSerializer);
+            var expandoObject = field.ToExpandoObject(jsonSerializer);
+            if (value is Exception && expandoObject is IDictionary<string, object> dictionary)
+            {
+                dictionary["Type"] = value.GetType().ToString();
+            }
+            return expandoObject;
+        }
+
+        private static string SerializeToJson(object value, JsonSerializer jsonSerializer)
+        {
+            var sb = new System.Text.StringBuilder(256);
+            var sw = new System.IO.StringWriter(sb, System.Globalization.CultureInfo.InvariantCulture);
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(sw))
+            {
+                jsonWriter.Formatting = jsonSerializer.Formatting;
+                jsonSerializer.Serialize(jsonWriter, value, value.GetType());
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/NLog.Targets.ElasticSearch/StringExtensions.cs
+++ b/src/NLog.Targets.ElasticSearch/StringExtensions.cs
@@ -26,12 +26,17 @@ namespace NLog.Targets.ElasticSearch
                 case "System.Int64":
                     return Convert.ToInt64(field, formatProvider);
                 case "System.Object":
-                    using (var reader = new JsonTextReader(new StringReader(field)))
-                    {
-                        return ((ExpandoObject)jsonSerializer.Deserialize(reader, typeof(ExpandoObject))).ReplaceDotInKeys(alwaysCloneObject: false);
-                    }
+                    return field.ToExpandoObject(jsonSerializer);
                 default:
                     return field;
+            }
+        }
+
+        public static ExpandoObject ToExpandoObject(this string field, JsonSerializer jsonSerializer)
+        {
+            using (var reader = new JsonTextReader(new StringReader(field)))
+            {
+                return ((ExpandoObject)jsonSerializer.Deserialize(reader, typeof(ExpandoObject))).ReplaceDotInKeys(alwaysCloneObject: false);
             }
         }
     }


### PR DESCRIPTION
Protection again stack-overflow from cyclic references. See also #114 + #109 + #102

New setting `MaxRecursionLimit` to enable safe conversion to ExpandoObject for advanced object-types. Thus avoiding issues with stackoverflow in Elasticsearch.Net.

- `MaxRecursionLimit="-1"` - **Default** Let Elasticsearch.Net handle all the reflection.
- `MaxRecursionLimit="0"` - Perform ToString on everything without doing reflection.
- `MaxRecursionLimit="1"` - Reflection only performed on initial object, where all properties are converted as ToString.
- `MaxRecursionLimit="2"` - Full reflection but with ignore-handling of cyclic references.