### PR TITLE
feat: skip jsonserialize the entire world when meeting deep reflection types

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -406,7 +406,7 @@ namespace NLog.Targets.ElasticSearch
             jsonSerializerSettings.Converters.Add(new StringEnumConverter());
             jsonSerializerSettings.Converters.Add(new JsonToStringConverter(typeof(System.Reflection.Assembly)));
             jsonSerializerSettings.Converters.Add(new JsonToStringConverter(typeof(System.Reflection.Module)));
-            jsonSerializerSettings.Converters.Add(new JsonToStringConverter(typeof(System.Reflection.MethodInfo)));
+            jsonSerializerSettings.Converters.Add(new JsonToStringConverter(typeof(System.Reflection.MemberInfo)));
             jsonSerializerSettings.Error = (sender, args) =>
             {
                 InternalLogger.Warn(args.ErrorContext.Error, $"Error serializing exception property '{args.ErrorContext.Member}', property ignored");


### PR DESCRIPTION
Fixing Typo. It should be `MemberInfo` (Base-class) and not `MethodInfo`.

#### Checklist
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
