### PR TITLE
docs: make it clear how to set the uri attribute in xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [wiki](https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch/wiki) f
   </extensions>
   <targets>
     <target name="elastic" xsi:type="BufferingWrapper" flushTimeout="5000">
-      <target xsi:type="ElasticSearch"/>
+      <target xsi:type="ElasticSearch" uri="http://localhost:9200/" />
     </target>
   </targets>
   <rules>


### PR DESCRIPTION
make it clear how to set the uri attribute in xml
The first time I try to set the uri, I mistakenly set it on `<target name="elastic" xsi:type="BufferingWrapper" flushTimeout="5000">`


