### PR TITLE
feat: Skip jsonserialize of System.Net.IpAddress since properties throws exceptions

### DIFF
--- a/src/NLog.Targets.ElasticSearch/JsonToStringConverter.cs
+++ b/src/NLog.Targets.ElasticSearch/JsonToStringConverter.cs
@@ -24,7 +24,11 @@ namespace NLog.Targets.ElasticSearch
             }
             else
             {
+                // Convert into a JSON object, so it can be converted back to ExpandoObject
+                writer.WriteStartObject();
+                writer.WritePropertyName(_type.Name);
                 writer.WriteValue(value.ToString());
+                writer.WriteEndObject();
             }
         }
 


### PR DESCRIPTION
Trying to resolve #129 when using `MaxRecursionLimit="2"`. Better handling of Microsoft-Logger output on [LogRequestFinished](https://github.com/aspnet/Hosting/blob/f9d145887773e0c650e66165e0c61886153bcc0b/src/Microsoft.AspNetCore.Hosting/Internal/HostingApplicationDiagnostics.cs#L182) in AspNetCore.

Also discovered that `ExpandoObject`-logic doesn't work well with `JsonToStringConverter`. Now changed  `JsonToStringConverter` to generate output for an json-object so it can be converted into `ExpandoObject`:

```
2020-07-09 09:42:56.2691 Error ElasticSearch: Error while formatting property: MethodInfo Exception: System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Dynamic.ExpandoObject'.
   at NLog.Targets.ElasticSearch.StringExtensions.ToExpandoObject(String field, JsonSerializer jsonSerializer)
   at NLog.Targets.ElasticSearch.ObjectConverter.FormatToExpandoObject(Object value, JsonSerializer jsonSerializer)
```

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
