### PR TITLE
feat: Enable override of jsonserialize for additional object types

### DIFF
--- a/src/NLog.Targets.ElasticSearch.Tests/App.config
+++ b/src/NLog.Targets.ElasticSearch.Tests/App.config
@@ -10,10 +10,11 @@
     <targets>
       <target name="elastic" xsi:type="BufferingWrapper" flushTimeout="5000">
         <target xsi:type="ElasticSearch" layout="${logger} | ${threadid} | ${message}" includeAllProperties="true" requireAuth="true" username="user" password="pwd">
-          <field name="user" layout="${windows-identity:userName=True:domain=False}"/>
+          <field name="user" layout="${environment-user}"/>
           <field name="host" layout="${machinename}"/>
           <field name="number" layout="1" layoutType="System.Int32"/>
           <field name="test" layout="${event-properties:item=test}"/>
+          <typeconverter objecttype="System.Uri, System.Private.Uri" />
         </target>
       </target>
     </targets>

--- a/src/NLog.Targets.ElasticSearch.Tests/IntegrationTests.cs
+++ b/src/NLog.Targets.ElasticSearch.Tests/IntegrationTests.cs
@@ -16,9 +16,16 @@ namespace NLog.Targets.ElasticSearch.Tests
             this.testOutputHelper = testOutputHelper;
         }
 
-        private class ExceptionWithPropertiesThatThrow : Exception
+        public class BadLogException : Exception
         {
-            public object ThisPropertyThrowsOnGet => throw new ObjectDisposedException("DisposedObject");
+            public object[] BadArray { get; }
+            public System.Reflection.Assembly BadProperty => typeof(BadLogException).Assembly;
+            public object ExceptionalBadProperty => throw new System.NotSupportedException();
+
+            public BadLogException()
+            {
+                BadArray = new object[] { this };
+            }
         }
 
         [Theory(Skip = "Integration")]
@@ -53,7 +60,7 @@ namespace NLog.Targets.ElasticSearch.Tests
 
                 var logger = LogManager.GetLogger("Example");
 
-                logger.Error(new ExceptionWithPropertiesThatThrow(), "Boom");
+                logger.Error(new BadLogException(), "Boom");
 
                 LogManager.Flush();
             }

--- a/src/NLog.Targets.ElasticSearch/ObjectTypeConvert.cs
+++ b/src/NLog.Targets.ElasticSearch/ObjectTypeConvert.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Newtonsoft.Json;
+using NLog.Config;
+
+namespace NLog.Targets.ElasticSearch
+{
+    /// <summary>
+    /// Additional type converter configuration
+    /// </summary>
+    [NLogConfigurationItem]
+    public class ObjectTypeConvert
+    {
+        /// <summary>
+        /// Gets or sets the ObjectType that should override <see cref="JsonConverter"/>
+        /// </summary>
+        public Type ObjectType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JsonConverter to include in <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        public JsonConverter JsonConverter
+        {
+            get => _jsonConverter ?? (_jsonConverter = ObjectType != null ? new JsonToStringConverter(ObjectType) : null);
+            set => _jsonConverter = value;
+        }
+        private JsonConverter _jsonConverter;
+
+        /// <summary>
+        /// Initializes new instance of <see cref="ObjectTypeConvert"/>
+        /// </summary>
+        public ObjectTypeConvert()
+            :this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes new instance of <see cref="ObjectTypeConvert"/> where it performs ToString for the input <paramref name="objectType"/>
+        /// </summary>
+        public ObjectTypeConvert(Type objectType)
+        {
+            ObjectType = objectType;
+        }
+    }
+}


### PR DESCRIPTION
Alternative implementation of #126 that resolves #127

Then you can do this:

```xml
        <target xsi:type="ElasticSearch">
          <typeconverter objecttype="System.Uri, System.Private.Uri" />
        </target>
```

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
