### PR TITLE
feat: add support for api token authentication without cloudId

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -274,15 +274,18 @@ namespace NLog.Targets.ElasticSearch
                 ? new ConnectionConfiguration(connectionPool)
                 : new ConnectionConfiguration(connectionPool, ElasticsearchSerializer);
 
-            if (!string.IsNullOrWhiteSpace(username))
+            if (string.IsNullOrWhiteSpace(cloudId))
             {
-                config = config.BasicAuthentication(username, password);
-            }
-            else
-            {
-                if (!string.IsNullOrWhiteSpace(apiKey) && !string.IsNullOrWhiteSpace(apiKeyId))
+                if (!string.IsNullOrWhiteSpace(username))
                 {
-                    config = config.ApiKeyAuthentication(apiKeyId, apiKey);
+                    config = config.BasicAuthentication(username, password);
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(apiKey) && !string.IsNullOrWhiteSpace(apiKeyId))
+                    {
+                        config = config.ApiKeyAuthentication(apiKeyId, apiKey);
+                    }
                 }
             }
 

--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -150,7 +150,7 @@ namespace NLog.Targets.ElasticSearch
         /// <summary>
         /// Gets or sets the document type for the elasticsearch index.
         /// </summary>
-        public Layout DocumentType { get; set; }
+        public Layout DocumentType { get; set; } = "_doc";
 
         /// <summary>
         /// Gets or sets to only create index for the document if it does not already exist (put if absent). Required when request targets a data stream.

--- a/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using Elasticsearch.Net;
 using NLog.Layouts;
@@ -32,6 +33,7 @@ namespace NLog.Targets.ElasticSearch
         /// <summary>
         /// Set it to true if ElasticSearch uses BasicAuth
         /// </summary>
+        [Obsolete]
         bool RequireAuth { get; set; }
 
         /// <summary>


### PR DESCRIPTION
We can use an api token authentication without the cloud connection pool.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
