### PR TITLE
feat: better error handling from server bulk response.

### DIFF
--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -1,26 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-		<Description>An NLog target that utilises the elasticsearch low level client.</Description>
-		<PackageLicenseUrl>https://raw.githubusercontent.com/ReactiveMarkets/NLog.Targets.ElasticSearch/master/LICENSE</PackageLicenseUrl>
-		<PackageProjectUrl>https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch</PackageProjectUrl>
-		<PackageTags>NLog logging target log elasticsearch elastic search</PackageTags>
-		<Authors>ReactiveMarkets</Authors>
-		<Company>ReactiveMarkets</Company>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<SignAssembly>true</SignAssembly>
-		<DelaySign>false</DelaySign>
-		<AssemblyOriginatorKeyFile>NLog.Targets.ElasticSearch.snk</AssemblyOriginatorKeyFile>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Elasticsearch.Net" Version="7.13.2" />
-		<PackageReference Include="NEST" Version="7.13.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-		<PackageReference Include="NLog" Version="4.6.8" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <Description>An NLog target that utilises the elasticsearch low level client.</Description>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/ReactiveMarkets/NLog.Targets.ElasticSearch/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch</PackageProjectUrl>
+    <PackageTags>NLog logging target log elasticsearch elastic search</PackageTags>
+    <Authors>ReactiveMarkets</Authors>
+    <Company>ReactiveMarkets</Company>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>NLog.Targets.ElasticSearch.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Elasticsearch.Net" Version="7.13.2" />
+    <PackageReference Include="NEST" Version="7.13.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -1,25 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Description>An NLog target that utilises the elasticsearch low level client.</Description>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/ReactiveMarkets/NLog.Targets.ElasticSearch/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch</PackageProjectUrl>
-    <PackageTags>NLog logging target log elasticsearch elastic search</PackageTags>
-    <Authors>ReactiveMarkets</Authors>
-    <Company>ReactiveMarkets</Company>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>NLog.Targets.ElasticSearch.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+		<Description>An NLog target that utilises the elasticsearch low level client.</Description>
+		<PackageLicenseUrl>https://raw.githubusercontent.com/ReactiveMarkets/NLog.Targets.ElasticSearch/master/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch</PackageProjectUrl>
+		<PackageTags>NLog logging target log elasticsearch elastic search</PackageTags>
+		<Authors>ReactiveMarkets</Authors>
+		<Company>ReactiveMarkets</Company>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<SignAssembly>true</SignAssembly>
+		<DelaySign>false</DelaySign>
+		<AssemblyOriginatorKeyFile>NLog.Targets.ElasticSearch.snk</AssemblyOriginatorKeyFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="7.4.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Elasticsearch.Net" Version="7.13.2" />
+		<PackageReference Include="NEST" Version="7.13.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="NLog" Version="4.6.8" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
In some cases the `BytesResponse` flag Success is not enough to identify a failed index operation. We should rely on the `BulkResponse` that returns the items with errors. 

For example this will not log anything in the internal logger with the current approach:
`Successful (200) low level call on POST: /_bulk
{"took":0,"errors":true,"items":[{"index":{"_index":"logstash-2021.07.12","_type":"_doc","_id":"OTgmmnoBq3Eup03vE24t","status":403,"error":{"type":"security_exception","reason":"action [indices:data/write/bulk[s]] is unauthorized for API key id [NzgjmnoBq3Eup03vg25H] of user [elastic] on indices [logstash-2021.07.12], this action is granted by the index privileges [create_doc,create,delete,index,write,all]"}`

But the `BulkResponse` has the `Errors` flag and will include in this case the failed item in the `ItemsWithErrors` collection.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
