### PR TITLE
feat: Add support for EnableApiVersioningHeader option for servers v8+

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -134,6 +134,11 @@ namespace NLog.Targets.ElasticSearch
         public bool EnableHttpCompression { get; set; }
 
         /// <summary>
+        /// Set it to true to enable EnableApiVersioningHeader (Enables use of v8+ server)
+        /// </summary>
+        public bool EnableApiVersioningHeader { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the elasticsearch index to write to.
         /// </summary>
         [RequiredParameter]
@@ -327,6 +332,9 @@ namespace NLog.Targets.ElasticSearch
 
             if (EnableHttpCompression)
                 config = config.EnableHttpCompression();
+
+            if (EnableApiVersioningHeader)
+                config = config.EnableApiVersioningHeader();
 
             _client = new ElasticLowLevelClient(config);
 

--- a/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/IElasticSearchTarget.cs
@@ -134,5 +134,10 @@ namespace NLog.Targets.ElasticSearch
         /// <para>Default value is true.</para>
         /// </summary>
         bool IncludeDefaultFields { get; set; }
+
+        /// <summary>
+        /// Set it to true to enable EnableApiVersioningHeader (Enables use of v8+ server)
+        /// </summary>
+        bool EnableApiVersioningHeader { get; set; }
     }
 }


### PR DESCRIPTION
We have upgraded Elastic server to version 8.1.3 and experienced errors. After reading https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.17/connecting-to-elasticsearch-v8.html#enabling-compatibility-mode and https://github.com/elastic/elasticsearch-net/issues/6154 we tried setting the ELASTIC_CLIENT_APIVERSIONING environment variable which fixed it.

One of our applications, though, connects to two different Elastic servers, one for logging and one for a search index. The search index server is on version 7.10 which does not yet support ApiVersioningHeader, and we cannot upgrade it yet. Thus we need NLog target to run with EnableApiVersioningHeader and the other client without.

This PR adds support for enabling ApiVersioningHeader just for the NLog target from config.

A limitation is, that it will not work when enabling it for servers running <7.13 (as per https://github.com/elastic/elasticsearch-net/issues/6154#issuecomment-1095182360) but I think that could be adequately explained in documentation.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
