### PR TITLE
fix: Fix System.Type serialization

### DIFF
--- a/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
+++ b/src/NLog.Targets.ElasticSearch/ElasticSearchTarget.cs
@@ -232,6 +232,7 @@ namespace NLog.Targets.ElasticSearch
                 new ObjectTypeConvert(typeof(System.Reflection.MemberInfo)),   // Skip serializing all types in application
                 new ObjectTypeConvert(typeof(System.IO.Stream)),               // Skip serializing Stream properties, since they throw
                 new ObjectTypeConvert(typeof(System.Net.IPAddress)),           // Skip serializing IPAdress properties, since they throw when IPv6 address
+                new ObjectTypeConvert(typeof(System.Type))
             };
 
             _jsonSerializerSettings = new Lazy<JsonSerializerSettings>(() => CreateJsonSerializerSettings(false, ObjectTypeConverters), LazyThreadSafetyMode.PublicationOnly);


### PR DESCRIPTION
#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated

This PR fixed the following error:
```
2022-08-03 11:45:58.9930 Error ElasticSearch: Error while sending log messages Exception: Elasticsearch.Net.UnexpectedElasticsearchClientException: Failed to serialize anonymous type: System.RuntimeType.
The type defines the following properties:
'IsCollectible' of type System.Boolean
'DeclaringMethod' of type System.Reflection.MethodBase
'FullName' of type System.String
'AssemblyQualifiedName' of type System.String
'Namespace' of type System.String
'GUID' of type System.Guid
'GenericParameterAttributes' of type System.Reflection.GenericParameterAttributes
...
```
