### PR TITLE
Revert to Elasticsearch low-level-client with minimal parsing of server-response

### DIFF
--- a/src/NLog.Targets.ElasticSearch.Tests/NLog.Targets.ElasticSearch.Tests.csproj
+++ b/src/NLog.Targets.ElasticSearch.Tests/NLog.Targets.ElasticSearch.Tests.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NLog.Targets.ElasticSearch\NLog.Targets.ElasticSearch.csproj" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
+++ b/src/NLog.Targets.ElasticSearch/NLog.Targets.ElasticSearch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <Description>An NLog target that utilises the elasticsearch low level client.</Description>
     <PackageLicenseUrl>https://raw.githubusercontent.com/ReactiveMarkets/NLog.Targets.ElasticSearch/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/ReactiveMarkets/NLog.Targets.ElasticSearch</PackageProjectUrl>
@@ -14,10 +14,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elasticsearch.Net" Version="7.13.2" />
-    <PackageReference Include="NEST" Version="7.13.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.8.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts #149 to avoid issues in server-response-parsing.

Added new setting `EnableDebugMode` that should improve server-error-respone-details